### PR TITLE
Fix small bug in enemyManager.js

### DIFF
--- a/enemyManager.js
+++ b/enemyManager.js
@@ -10,11 +10,11 @@ function enemyManager(x, y){
 	this.update = function(dt){
 		for(var e = 0; e < this.enemies.length; e++){
 			var enemy = this.enemies[e];
-			enemy.update(dt);
 			if(enemy.state == "DEAD"){				
 				this.enemies.splice(e, 1);
 				e--;
 			}
+			enemy.update(dt);
 		}
 
 	}


### PR DESCRIPTION
If enemy.update() is executed before "DEAD" state check, followBot cannot be killed in "FOLLOW" state.
